### PR TITLE
refactor(TMC2130_Basics): optimize SPI flush loops

### DIFF
--- a/src/TMC2130_Basics.cpp
+++ b/src/TMC2130_Basics.cpp
@@ -35,7 +35,8 @@ uint8_t TMC2130_Basics::read_STAT()
   _status = SPI.transfer(0x00);
 
   // flush 4 bytes
-  for (int i = 0; i < 4; i++) {
+  constexpr uint8_t BYTES_TO_FLUSH = 4;
+  for (uint8_t i = 0; i < BYTES_TO_FLUSH; ++i) {
     SPI.transfer(0x00);
   }
 

--- a/src/TMC2130_Basics.cpp
+++ b/src/TMC2130_Basics.cpp
@@ -55,7 +55,8 @@ uint8_t TMC2130_Basics::read_REG(uint8_t address, uint32_t *data)
   _status = SPI.transfer(address&~FB_TMC_WRITE);
 
   // flush 4 bytes
-  for (int i = 0; i < 4; i++) {
+  constexpr uint8_t BYTES_TO_FLUSH = 4;
+  for (uint8_t i = 0; i < BYTES_TO_FLUSH; ++i) {
     SPI.transfer(0x00);
   }
 


### PR DESCRIPTION
This PR combines two commits refactoring the SPI flush loops in TMC2130_Basics:

- Replaced magic numbers with `constexpr uint8_t BYTES_TO_FLUSH = 4`
- Changed loop counters from `int` to `uint8_t`
- Replaced post-increment `i++` with pre-increment `++i` for consistency

No functional changes, just code clean-up and minor performance improvements.
